### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/external.js
+++ b/lib/external.js
@@ -1,7 +1,7 @@
 
 var async       = require("async"),
     _           = require("lodash"),
-    uuid        = require("node-uuid"),
+    uuid        = require("uuid"),
     ALL_CHANNEL = "___all___",
     SYNC_CHANNEL = "___sync___",
     utils       = require("./utils");

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -1,7 +1,7 @@
 
 var async        = require("async"),
     _            = require("lodash"),
-    uuid         = require("node-uuid"),
+    uuid         = require("uuid"),
     utils        = require("./utils"),
     ALL_CHANNEL  = "___all___",
     SYNC_CHANNEL = "___sync___",

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@
 var async        = require("async"),
     _            = require("lodash"),
     EventEmitter = require("events").EventEmitter,
-    uuid         = require("node-uuid"),
+    uuid         = require("uuid"),
     TOKEN_TTL    = 30; // seconds
 
 var extendError = function(e){

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "async": "^0.2.10",
     "lodash": "^2.4.1",
-    "node-uuid": "^1.4.1"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "chai": "^1.9.1",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.